### PR TITLE
Correct RouteCollectorFactory feature description

### DIFF
--- a/docs/book/v3/features/container/factories.md
+++ b/docs/book/v3/features/container/factories.md
@@ -368,7 +368,6 @@ accepts a `Psr\Container\ContainerInterface` instance as the sole argument.
 ### RouteCollectorFactory
 
 - **Provides**: `Zend\Expressive\Router\RouteCollector`
-- **FactoryName**: `Zend\Expressive\Twig\TwigRendererFactory`
 - **Suggested Name**: `Zend\Expressive\Router\RouteCollector`
 - **Requires**:
     - `Zend\Expressive\Router\RouterInterface`


### PR DESCRIPTION
See here:
https://docs.zendframework.com/zend-expressive/v3/features/container/factories/#routecollectorfactory

`TwigRendererFactory ` under `RouteCollectorFactory`

- [x] Is this related to documentation?
  - [x] Typographical error
  - [ ] New documentation

P.S. Really appreciate all the work put in. Will try find the time to make pull requests for things I notice